### PR TITLE
User Configurable Postgres Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,15 @@ To run the docker container, you need to have the `docker-compose.yml` file. Dow
 Before running the file, you need to edit some fields:
 ```
 environment:
-  mode: local            # local or public, defaults to local
-  forte_server: <server> # only if mode is public
-  forte_email: <email>   # only if mode is public
+  mode: local                   # local or public, defaults to local
+  forte_server: <server>        # only if mode is public
+  forte_email: <email>          # only if mode is public
+  POSTGRES_HOST: <host/ip>      # hostname/ip of postgres server
+  POSTGRES_PORT: 5432           # postgres port (default=5432)
+  POSTGRES_DB: <db_name>        # Forte Database name
+  POSTGRES_USER: <db_user>      # Forte postgres username
+  POSTGRES_PASSWORD: <db_pw>    # Forte postgres password
+
 volumes:
   - <library>:/library   # The path to your music library
 ```
@@ -197,6 +203,12 @@ services:
             mode: public
             forte_server: forte.example.com
             forte_email: forte@example.com
+            POSTGRES_HOST: hostname
+            POSTGRES_PORT: 5432
+            POSTGRES_DB: forte
+            POSTGRES_USER: forte
+            POSTGRES_PASSWORD: forte
+
         volumes:
             - /home/forte/library:/library
     postgres:

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -13,15 +13,21 @@ services:
             mode: local
             forte_server: <server>
             forte_email: <email>
-        volumes:
+            POSTGRES_HOST: # Postgres Host/IP
+            POSTGRES_PORT: # Postgres Database Port (Default=5432)
+            POSTGRES_DB: # Set Postgres Database Name
+            POSTGRES_USER: # Set Postgres Username
+            POSTGRES_PASSWORD: # Set Postgres Password
+            
+       volumes:
             - <library>:/library
     postgres:
         image: kaangiray26/postgres:1.0
         restart: always
         environment:
-            POSTGRES_DB: forte
-            POSTGRES_USER: forte
-            POSTGRES_PASSWORD: forte
+            POSTGRES_DB: # Set Postgres Database Name
+            POSTGRES_USER: # Set Postgres Username
+            POSTGRES_PASSWORD: # Set Postgres Password
         volumes:
             - db-data:/var/lib/postgresql/data
         healthcheck:

--- a/server/js/db.js
+++ b/server/js/db.js
@@ -10,7 +10,16 @@ import mime from 'mime-types';
 import { exit } from 'process';
 
 const pgp = pgPromise();
-const db = pgp('postgres://forte:forte@postgres:5432/forte');
+
+// Use environment settings to connect to database.
+const db = pgp({
+    'host': process.env.POSTGRES_HOST ? process.env.POSTGRES_HOST : 'postgres',
+    'database': process.env.POSTGRES_DB ? process.env.POSTGRES_DB : 'forte',
+    'user': process.env.POSTGRES_USER ? process.env.POSTGRES_USER : 'forte',
+    'password': process.env.POSTGRES_PASSWORD ? process.env.POSTGRES_PASSWORD : 'forte',
+    'port': parseInt(process.env.POSTGRES_PORT ? process.env.POSTGRES_PORT : '5432')
+});
+
 const library_path = '/library';
 
 const exports = {


### PR DESCRIPTION
Before, the postgres connection details were hardcoded in server/db.js which prevents users from defining their own username/password or even postgres server.  This change allows you to change this.  I don't use individual postgres containers for each app, but rather a postgres cluster.  This change allows this.